### PR TITLE
Include generated examples

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,13 +9,14 @@ import "ace-builds/src-noconflict/theme-monokai";
 
 const apiUrl = "https://ufgjji253b.execute-api.us-east-1.amazonaws.com/prod";
 const defaultJsonObject = '{\n\t"foo": 5, \n\t"barBaz": "hello"\n}';
-const defaultOptions = { forceOptional: false, snakeCased: false };
+const defaultOptions = { forceOptional: false, snakeCased: false, includeExamples: false };
 const loadingMessage = "# loading...";
 const invalidJsonMessage = "# invalid json";
 
 type RequestOptions = {
   forceOptional: boolean;
   snakeCased: boolean;
+  includeExamples: boolean;
 };
 
 type RequestBody = {
@@ -30,7 +31,7 @@ function App() {
 
   useEffect(() => {
     if (validJson(jsonObject)) {
-      fetchConversion(jsonObject, options.forceOptional, options.snakeCased);
+      fetchConversion(jsonObject, options.forceOptional, options.snakeCased, options.includeExamples);
     } else {
       setPydanticModel(invalidJsonMessage);
     }
@@ -52,11 +53,12 @@ function App() {
   function fetchConversion(
     newValue: string,
     forceOptional: boolean,
-    snakeCased: boolean
+    snakeCased: boolean,
+    includeExamples: boolean
   ) {
     console.log("fetching");
     setPydanticModel(loadingMessage);
-    const requestOptions: RequestOptions = { forceOptional, snakeCased };
+    const requestOptions: RequestOptions = { forceOptional, snakeCased, includeExamples };
     const requestBody: RequestBody = {
       data: newValue,
       options: requestOptions,
@@ -135,6 +137,20 @@ function App() {
                 }
               />
               Alias camelCase fields as snake_case
+            </label>
+          </p>
+        </div>
+        <div className="field">
+          <p className="option">
+            <label className="checkbox">
+              <input
+                type="checkbox"
+                checked={options.includeExamples}
+                onChange={(e) =>
+                  setOptions({ ...options, snakeCased: e.target.checked })
+                }
+              />
+              Include examples for strings and numbers on the Fields.
             </label>
           </p>
         </div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -126,8 +126,8 @@ function App() {
             </label>
           </p>
         </div>
-        <div className="field">
-          <p className="option">
+        <div className="option">
+          <p className="control">
             <label className="checkbox">
               <input
                 type="checkbox"
@@ -147,7 +147,7 @@ function App() {
                 type="checkbox"
                 checked={options.includeExamples}
                 onChange={(e) =>
-                  setOptions({ ...options, snakeCased: e.target.checked })
+                  setOptions({ ...options, includeExamples: e.target.checked })
                 }
               />
               Include examples for strings and numbers on the Fields.

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -23,6 +23,7 @@ app.add_middleware(
 class Options(BaseModel):
     force_optional: bool = Field(False, alias="forceOptional")
     snake_cased: bool = Field(False, alias="snakeCased")
+    include_examples: bool = Field(False, alias="includeExamples")
 
 
 class BasicRequest(BaseModel):
@@ -39,6 +40,7 @@ async def convert(basic_request: BasicRequest):
             basic_request.data,
             options.force_optional,
             options.snake_cased,
+            options.include_examples,
         )
     }
 

--- a/server/app/scripts/generator.py
+++ b/server/app/scripts/generator.py
@@ -54,14 +54,3 @@ def translate(
     )
 
     return parser.parse()
-
-
-if __name__ == "__main__":
-    example = {
-        "id": "123",
-        "name": "foo",
-        "type": 1,
-        "is_real": False,
-    }
-    result = translate(example, False, False, True)
-    print(result)

--- a/server/app/scripts/generator.py
+++ b/server/app/scripts/generator.py
@@ -3,12 +3,44 @@ from typing import Dict, Any, Union
 from pydantic import Json
 from datamodel_code_generator.parser.jsonschema import JsonSchemaParser
 from genson import SchemaBuilder
+from genson.schema.strategies import String, Number
+
+
+class StringWithExample(String):
+
+    def add_object(self, obj):
+        super().add_object(obj)
+        if not hasattr(self, "example"):
+            self.example = obj
+
+    def to_schema(self):
+        schema = super().to_schema()
+        if hasattr(self, "example"):
+            schema['example'] = self.example
+        return schema
+
+
+class NumberWithExample(Number):
+    def add_object(self, obj):
+        super().add_object(obj)
+        if not hasattr(self, "example"):
+            self.example = obj
+
+    def to_schema(self):
+        schema = super().to_schema()
+        if hasattr(self, "example"):
+            schema['example'] = self.example
+        return schema
+
+
+class ExampleSchemaBuilder(SchemaBuilder):
+    EXTRA_STRATEGIES = (StringWithExample, NumberWithExample)
 
 
 def translate(
-    input_text: Union[Json, Dict[str, Any]], all_optional: bool, snake_case_field: bool
+    input_text: Union[Json, Dict[str, Any]], all_optional: bool, snake_case_field: bool, include_examples: bool = False
 ) -> str:
-    builder = SchemaBuilder()
+    builder = ExampleSchemaBuilder() if include_examples else SchemaBuilder()
     builder.add_object(input_text)
     schema = builder.to_schema()
     if all_optional:
@@ -18,6 +50,18 @@ def translate(
         source=json.dumps(schema),
         base_class="pydantic.BaseModel",
         snake_case_field=snake_case_field,
+        field_extra_keys={"example"} if include_examples else {},
     )
 
     return parser.parse()
+
+
+if __name__ == "__main__":
+    example = {
+        "id": "123",
+        "name": "foo",
+        "type": 1,
+        "is_real": False,
+    }
+    result = translate(example, False, False, True)
+    print(result)


### PR DESCRIPTION
It it's extremely nice to load examples when building an API, since the OpenAPI specification is going to contain an example value from the actual response. If you are building a validator for an actual object, you know more or less how the data should look like. Here are the relevant docs for this feature: https://fastapi.tiangolo.com/tutorial/schema-extra-example/

This MR adds another customizer to include the examples when generating the model. Here is a preview:

![jsontopydantic](https://user-images.githubusercontent.com/8211602/217911452-fa11f622-b45f-4dc8-87cb-619374c49117.gif)

Of course, when presented with multiple options, it will pick the first:

![image](https://user-images.githubusercontent.com/8211602/217911275-410709ec-810d-46f0-ac81-f978b0e7a293.png)

Closes #14 

Suggested and implemented during a Hackergarten: https://www.meetup.com/pt-BR/hackergarten-stuttgart/, thanks everyone who participated 😃 